### PR TITLE
Sonar Extension: ShellCheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           sonar-source-path: '.'
           sonar-metrics-path: './blahblah.json'
+          sonar-instance-port: '9999'
 
       - name: Check Sonar Metrics
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Sonarless Scan
         uses: ./
         with:
-          sonar-source-path: 'test-src'
+          sonar-source-path: '.'
           sonar-metrics-path: './blahblah.json'
 
       - name: Check Sonar Metrics

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Enjoy!!!
 To understand the sub-commands, just run `sonarless help`
 
 Usually, you only need to know 2 sub-commands
-- `sonarless scan`: to start scanning your code in the current directory will be uploaded for scanning. When the scan is done, just login webui into your local personal instance of sonarqube via [http://localhost:9000](http://localhost:9000) to get details from SonarQube. The default password for `admin` is `sonarless`
+- `sonarless scan`: to start scanning your code in the current directory will be uploaded for scanning. When the scan is done, just login webui into your local personal instance of sonarqube via [http://localhost:9234](http://localhost:9234) to get details from SonarQube. The default password for `admin` is `sonarless`
 
 - `sonarless results`: to generate `sonar-metrics.json` metrics file in your current directory
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Please refer to the [release page](https://github.com/gitricko/sonarless/release
 - [Scan all files from git root directory](#Sonar-scan-all-files-from-git-root-directory)
 - [Scan particular folder from git root directory](#Scan-particular-folder-from-git-root-directory)
 - [Scan code and fail build if metrics is below expectation](#Scan-code-and-fail-build-if-metrics-is-below-expectation)
+- [Options to change local sonarqube server port](#Options-to-change-local-sonarqube-server-port)
 
 ## Sonar scan all files from git root directory
 
@@ -91,6 +92,23 @@ jobs:
           echo "# of vulnerabilities = ${VULN}"
           [ ${VULN} -eq "0" ]
 ```
+
+## Options to change local sonarqube server port
+Just in case your local machine/GHA container need to use the default port of `9234`
+```yaml
+jobs:
+  Sonarless-Scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sonarless Scan
+        uses: gitricko/sonarless@v1
+        with:
+          sonar-instance-port: '1234'
+```
+
 # Use Sonarless in your Local Dev
 
 To install automation scriptlets, paste and run the following in a terminal:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,9 @@ runs:
   using: "composite"
   steps:
     - name: Get Docker Deps
-      run: ${{ github.action_path }}/makefile.sh docker-deps-get
+      run: |
+        ${{ github.action_path }}/makefile.sh docker-deps-get
+        ${{ github.action_path }}/makefile.sh sonar-ext-get
       shell: bash
 
     - name: Scanning

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: "SonarQube Metrics JSON Path from Git Root"
     required: true
     default: ./sonar-matrics.json
+  sonar-instance-port:
+    description: "SonarQube Instance Port"
+    required: false
 
 runs:
   using: "composite"
@@ -37,6 +40,7 @@ runs:
         SONAR_PROJECT_KEY: ${{inputs.sonar-project-key}}
         SONAR_SOURCE_PATH: ${{inputs.sonar-source-path}}
         SONAR_METRICS_PATH: ${{inputs.sonar-metrics-path}}
+        SONAR_INSTANCE_PORT: ${{ inputs.sonar-instance-port }}
         SONAR_GITROOT: ${{ github.workspace }}
 
     - name: Scan Results
@@ -47,4 +51,5 @@ runs:
         SONAR_PROJECT_KEY: ${{inputs.sonar-project-key}}
         SONAR_SOURCE_PATH: ${{inputs.sonar-source-path}}
         SONAR_METRICS_PATH: ${{inputs.sonar-metrics-path}}
+        SONAR_INSTANCE_PORT: ${{ inputs.sonar-instance-port }}
         SONAR_GITROOT: ${{ github.workspace }}

--- a/install.sh
+++ b/install.sh
@@ -126,12 +126,19 @@ echo "Installing Sonarless helper scripts..."
 # Create directory structure
 mkdir -p "${SONARLESS_DIR}"
 
-# Download makefile.sh
-echo "* Downloading..."
-curl --fail --location --progress-bar "${SONARLESS_SOURCES}" > "${SONARLESS_DIR}/makefile.sh"
-chmod +x ${SONARLESS_DIR}/makefile.sh
-
 set +e
+# Download makefile.sh depending which env (git or over curl)
+# Check if you are in sonarless git
+[ -d ./.git ] && git remote get-url origin | grep sonarless 2>&1 > /dev/null
+if [ $? -eq 0 ]; then
+	echo "* Copying from local git..."
+	cp -f ./makefile.sh "${SONARLESS_DIR}"
+else
+	echo "* Downloading..."
+	curl --fail --location --progress-bar "${SONARLESS_SOURCES}" > "${SONARLESS_DIR}/makefile.sh"
+	chmod +x ${SONARLESS_DIR}/makefile.sh
+fi
+
 # Create alias in ~/.bashrc ~/.zshrc if available
 [[ -s "${sonarless_bashrc}" ]] && grep 'sonarless' ${sonarless_bashrc}
 if [ $? -ne 0 ];then 

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ echo '              \__ \| (_) || | | || (_| || |   | ||  __/\__ \\__ \ '
 echo '              |___/ \___/ |_| |_| \__,_||_|   |_| \___||___/|___/ '
 echo ''
 echo ''
-echo '                                                                        Now attempting installation...'
+echo '                                                     Now attempting installation...'
 echo ''                                                                 
 
 

--- a/makefile.sh
+++ b/makefile.sh
@@ -60,9 +60,9 @@ function start() {
         docker run -d --name ${SONAR_INSTANCE_NAME} -p 9000:9000  \
             -v "${SONAR_EXTENSION_DIR}:/opt/sonarqube/extensions/plugins" \
             -v "${SONAR_EXTENSION_DIR}:/usr/local/bin" \
-            sonarqube
+            sonarqube 2>&1 > /dev/null 
     else
-        docker start ${SONAR_INSTANCE_NAME} 
+        docker start ${SONAR_INSTANCE_NAME} 2>&1 > /dev/null 
     fi
 
     # 1. Wait for services to be up


### PR DESCRIPTION
## Objective

- Enable extension download - Add ShellCheck and its plugin (in future any plugin is possible)
- Ability to change local docker port for sonarqube. Also change default to 9234
- Make testing makefile.sh easier by detecting if you are in sonarless git or not.