### PR TITLE
Upgrade SonarQube to 10.6-community

### DIFF
--- a/makefile.sh
+++ b/makefile.sh
@@ -10,7 +10,7 @@ export SONAR_METRICS_PATH=${SONAR_METRICS_PATH:-"./sonar-metrics.json"}
 export SONAR_EXTENSION_DIR="${HOME}/.sonarless/extensions"
 
 export DOCKER_SONAR_CLI=${DOCKER_SONAR_CLI:-"sonarsource/sonar-scanner-cli:10.0"}
-export DOCKER_SONAR_SERVER=${DOCKER_SONAR_SERVER:-"sonarqube:10.5-community"}
+export DOCKER_SONAR_SERVER=${DOCKER_SONAR_SERVER:-"sonarqube:10.6-community"}
 
 export CLI_NAME="sonarless"
 


### PR DESCRIPTION
# Objective

Update to 10.6-community since it is release on 25th June
https://www.sonarsource.com/blog/sonarqube-10-6-release-announcement/

To use the latest for GHA, use `uses: gitricko/sonarless@main`