### PR TITLE
Potential fix for code scanning alert no. 71: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '55 23 * * 5' # Runs at 23:55 every Friday
 
+permissions:
+  contents: read
+
 jobs:
   sonarless-cli-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gitricko/sonarless/security/code-scanning/71](https://github.com/gitricko/sonarless/security/code-scanning/71)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily reads repository contents and does not perform any write operations, the minimal permissions required are `contents: read`. This block can be added at the root level of the workflow to apply to all jobs, ensuring consistency and adherence to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
