### PR TITLE
Potential fix for code scanning alert no. 76: Code injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,32 +25,36 @@ runs:
   using: "composite"
   steps:
     - name: Get Docker Deps
+      env:
+        ACTION_PATH: ${{ github.action_path }}
       run: |
-        ${{ github.action_path }}/makefile.sh docker-deps-get
-        ${{ github.action_path }}/makefile.sh sonar-ext-get
+        $ACTION_PATH/makefile.sh docker-deps-get
+        $ACTION_PATH/makefile.sh sonar-ext-get
       shell: bash
 
     - name: Scanning
-      run: ${{ github.action_path }}/makefile.sh scan
-      shell: bash
       env:
+        ACTION_PATH: ${{ github.action_path }}
         SONAR_PROJECT_NAME: ${{inputs.sonar-project-name}}
         SONAR_PROJECT_KEY: ${{inputs.sonar-project-key}}
         SONAR_SOURCE_PATH: ${{inputs.sonar-source-path}}
         SONAR_METRICS_PATH: ${{inputs.sonar-metrics-path}}
         SONAR_INSTANCE_PORT: ${{ inputs.sonar-instance-port }}
         SONAR_GITROOT: ${{ github.workspace }}
+      run: $ACTION_PATH/makefile.sh scan
+      shell: bash
 
     - name: Scan Results
-      run: ${{ github.action_path }}/makefile.sh results
-      shell: bash
       env:
+        ACTION_PATH: ${{ github.action_path }}
         SONAR_PROJECT_NAME: ${{inputs.sonar-project-name}}
         SONAR_PROJECT_KEY: ${{inputs.sonar-project-key}}
         SONAR_SOURCE_PATH: ${{inputs.sonar-source-path}}
         SONAR_METRICS_PATH: ${{inputs.sonar-metrics-path}}
         SONAR_INSTANCE_PORT: ${{ inputs.sonar-instance-port }}
         SONAR_GITROOT: ${{ github.workspace }}
+      run: $ACTION_PATH/makefile.sh results
+      shell: bash
 
 branding:
   icon: "check-circle"


### PR DESCRIPTION
Potential fix for [https://github.com/gitricko/sonarless/security/code-scanning/76](https://github.com/gitricko/sonarless/security/code-scanning/76)

To fix the issue, the `github.action_path` variable should be assigned to an intermediate environment variable, and the environment variable should be referenced using shell-native syntax (`$VAR`) in the `run:` commands. This approach ensures that the variable is handled securely and avoids direct interpolation in the shell command.

The following changes will be made:
1. Define an environment variable `ACTION_PATH` to store the value of `github.action_path`.
2. Update the `run:` commands to reference the `ACTION_PATH` variable using `$ACTION_PATH` instead of `${{ github.action_path }}`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
