### PR TITLE
Add devcontainer setup and upgrade SonarQube to 26.4.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,5 @@
     }
   },
   "postCreateCommand": "bash ./.devcontainer/post-create-cmd.sh",
-  "postStartCommand": "bash echo '[post-start-cmd.sh] Container started' >> /tmp/post-start-cmd.log"
+  "postStartCommand": "bash -c \"echo '[post-start-cmd.sh] Container started' >> /tmp/post-start-cmd.log\""
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Hermes-Agent",
+  "customizations": {
+    "vscode": {
+      "extensions": ["saoudrizwan.claude-dev","joaompfp.hermes-ai-agent"]
+    }
+  },
+  "postCreateCommand": "bash ./.devcontainer/post-create-cmd.sh",
+  "postStartCommand": "bash echo '[post-start-cmd.sh] Container started' >> /tmp/post-start-cmd.log"
+}

--- a/.devcontainer/post-create-cmd.sh
+++ b/.devcontainer/post-create-cmd.sh
@@ -13,7 +13,8 @@ else
 fi
 
 # Install hermes-agent
-curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup
+HERMES_VERSION="v2026.5.7"
+curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_VERSION}/scripts/install.sh" | bash -s -- --skip-setup
 npm cache clean --force
 sudo rm -rf /var/lib/apt/lists/* 
 

--- a/.devcontainer/post-create-cmd.sh
+++ b/.devcontainer/post-create-cmd.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Install modelrelay globally
+sudo npm install modelrelay -g --prefix /usr/local/lib/modelrelay
+sudo ln -s /usr/local/lib/modelrelay/bin/modelrelay /usr/local/bin/modelrelay
+sudo npm cache clean --force
+
+echo "[post-create-cmd.sh] Starting modelrelay in the background..."
+if command -v modelrelay &>/dev/null; then
+  setsid /usr/local/bin/modelrelay >> /tmp/modelrelay.log 2>&1 &
+else
+  echo "[post-create-cmd.sh] modelrelay not found, skipping start"
+fi
+
+# Install hermes-agent
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup
+npm cache clean --force
+sudo rm -rf /var/lib/apt/lists/* 
+
+# Configure hermes defaults if first run
+if command -v hermes &>/dev/null && [ -d "$HOME/.hermes/sessions" ] && [ -z "$(ls -A "$HOME/.hermes/sessions")" ]; then
+  echo "[post-create-cmd.sh] No sessions found, setting up default configuration for custom provider"
+  hermes config set model.provider custom
+  hermes config set model.base_url http://localhost:7352/v1
+  hermes config set model.default auto-fastest
+fi

--- a/.devcontainer/post-create-cmd.sh
+++ b/.devcontainer/post-create-cmd.sh
@@ -2,7 +2,7 @@
 
 # Install modelrelay globally
 sudo npm install modelrelay -g --prefix /usr/local/lib/modelrelay
-sudo ln -s /usr/local/lib/modelrelay/bin/modelrelay /usr/local/bin/modelrelay
+sudo ln -sf /usr/local/lib/modelrelay/bin/modelrelay /usr/local/bin/modelrelay
 sudo npm cache clean --force
 
 echo "[post-create-cmd.sh] Starting modelrelay in the background..."

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub Release](https://img.shields.io/github/v/release/gitricko/sonarless)
 ![GitHub commits since latest release](https://img.shields.io/github/commits-since/gitricko/sonarless/latest)
 
-# Sonarless v1.3
+# Sonarless v1.4
 
 This developer-friendly CLI and GitHub Action enable SonarQube scanning for your repository without the need for a dedicated hosted SonarQube server. It starts a SonarQube Docker instance, allowing developers to scan code, check results, and generate a JSON metrics file for automation. This ensures you can easily assess and maintain the quality of your code.
 
@@ -62,7 +62,7 @@ This CLI works perfectly with Github CodeSpace
 
 <!-- start usage -->
 ```yaml
-- uses: gitricko/sonarless@v1.3
+- uses: gitricko/sonarless@v1.4
   with:
     # Folder path to scan from git-root
     # Default: . 

--- a/makefile.sh
+++ b/makefile.sh
@@ -9,8 +9,8 @@ export SONAR_SOURCE_PATH=${SONAR_SOURCE_PATH:-"."}
 export SONAR_METRICS_PATH=${SONAR_METRICS_PATH:-"./sonar-metrics.json"}
 export SONAR_EXTENSION_DIR="${HOME}/.sonarless/extensions"
 
-export DOCKER_SONAR_CLI=${DOCKER_SONAR_CLI:-"sonarsource/sonar-scanner-cli:11.3"}
-export DOCKER_SONAR_SERVER=${DOCKER_SONAR_SERVER:-"sonarqube:25.5.0.107428-community"}
+export DOCKER_SONAR_CLI=${DOCKER_SONAR_CLI:-"sonarsource/sonar-scanner-cli:12.1"}
+export DOCKER_SONAR_SERVER=${DOCKER_SONAR_SERVER:-"sonarqube:26.4.0.121862-community"}
 
 export CLI_NAME="sonarless"
 


### PR DESCRIPTION
This pull request sets up a development container for the Hermes-Agent project, automating the installation and configuration of required tools and updating dependencies for SonarQube analysis. The main changes focus on developer environment setup and keeping analysis tools up to date.

**Development container setup:**

* Added `.devcontainer/devcontainer.json` to define the container environment, including VS Code extensions, and to specify commands to run after container creation and startup.
* Added `.devcontainer/post-create-cmd.sh` script to automatically install and start `modelrelay`, install `hermes-agent`, and configure default settings for Hermes if it's a fresh environment.

**Dependency updates:**

* Updated SonarQube Docker images in `makefile.sh` to use newer versions for both the CLI (`sonar-scanner-cli:12.1`) and server (`sonarqube:26.4.0.121862-community`).